### PR TITLE
Strict session validation

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -116,6 +116,7 @@ An example [oauth2-proxy.cfg]({{ site.gitweb }}/contrib/oauth2-proxy.cfg.example
 | `-ssl-upstream-insecure-skip-verify` | bool | skip validation of certificates presented when using HTTPS upstreams | false |
 | `-standard-logging` | bool | Log standard runtime information | true |
 | `-standard-logging-format` | string | Template for standard log lines | see [Logging Configuration](#logging-configuration) |
+| `-strict-session-validation` | bool | fully validate the session state from tokens on every request (provider dependent) | false |
 | `-tls-cert-file` | string | path to certificate file | |
 | `-tls-key-file` | string | path to private key file | |
 | `-upstream` | string \| list | the http url(s) of the upstream endpoint, file:// paths for static files or `static://<status_code>` for static response. Routing is based on the path | |

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
 	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
 	flagSet.StringSlice("upstream", []string{}, "the http url(s) of the upstream endpoint, file:// paths for static files or static://<status_code> for static response. Routing is based on the path")
+	flagSet.Bool("always-validate-session", false, "TODO WRITE ME")
 	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")
 	flagSet.Bool("set-basic-auth", false, "set HTTP Basic Auth information in response (useful in Nginx auth_request mode)")
 	flagSet.Bool("prefer-email-to-user", false, "Prefer to use the Email address as the Username when passing information to upstream. Will only use Username if Email is unavailable, eg. htaccess authentication. Used in conjunction with -pass-basic-auth and -pass-user-headers")

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
 	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
 	flagSet.StringSlice("upstream", []string{}, "the http url(s) of the upstream endpoint, file:// paths for static files or static://<status_code> for static response. Routing is based on the path")
-	flagSet.Bool("always-validate-session", false, "TODO WRITE ME")
+	flagSet.Bool("strict-session-validation", false, "fully validate the session state from tokens on every request (provider dependent)")
 	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")
 	flagSet.Bool("set-basic-auth", false, "set HTTP Basic Auth information in response (useful in Nginx auth_request mode)")
 	flagSet.Bool("prefer-email-to-user", false, "Prefer to use the Email address as the Username when passing information to upstream. Will only use Username if Email is unavailable, eg. htaccess authentication. Used in conjunction with -pass-basic-auth and -pass-user-headers")

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -86,35 +86,35 @@ type OAuthProxy struct {
 	AuthOnlyPath      string
 	UserInfoPath      string
 
-	redirectURL           *url.URL // the url to receive requests at
-	whitelistDomains      []string
-	provider              providers.Provider
-	providerNameOverride  string
-	sessionStore          sessionsapi.SessionStore
-	ProxyPrefix           string
-	SignInMessage         string
-	HtpasswdFile          *HtpasswdFile
-	DisplayHtpasswdForm   bool
-	serveMux              http.Handler
-	alwaysValidateSession bool
-	SetXAuthRequest       bool
-	PassBasicAuth         bool
-	SetBasicAuth          bool
-	SkipProviderButton    bool
-	PassUserHeaders       bool
-	BasicAuthPassword     string
-	PassAccessToken       bool
-	SetAuthorization      bool
-	PassAuthorization     bool
-	PreferEmailToUser     bool
-	skipAuthRegex         []string
-	skipAuthPreflight     bool
-	skipJwtBearerTokens   bool
-	jwtBearerVerifiers    []*oidc.IDTokenVerifier
-	compiledRegex         []*regexp.Regexp
-	templates             *template.Template
-	Banner                string
-	Footer                string
+	redirectURL             *url.URL // the url to receive requests at
+	whitelistDomains        []string
+	provider                providers.Provider
+	providerNameOverride    string
+	sessionStore            sessionsapi.SessionStore
+	ProxyPrefix             string
+	SignInMessage           string
+	HtpasswdFile            *HtpasswdFile
+	DisplayHtpasswdForm     bool
+	serveMux                http.Handler
+	strictSessionValidation bool
+	SetXAuthRequest         bool
+	PassBasicAuth           bool
+	SetBasicAuth            bool
+	SkipProviderButton      bool
+	PassUserHeaders         bool
+	BasicAuthPassword       string
+	PassAccessToken         bool
+	SetAuthorization        bool
+	PassAuthorization       bool
+	PreferEmailToUser       bool
+	skipAuthRegex           []string
+	skipAuthPreflight       bool
+	skipJwtBearerTokens     bool
+	jwtBearerVerifiers      []*oidc.IDTokenVerifier
+	compiledRegex           []*regexp.Regexp
+	templates               *template.Template
+	Banner                  string
+	Footer                  string
 }
 
 // UpstreamProxy represents an upstream server to proxy to
@@ -297,32 +297,32 @@ func NewOAuthProxy(opts *Options, validator func(string) bool) *OAuthProxy {
 		AuthOnlyPath:      fmt.Sprintf("%s/auth", opts.ProxyPrefix),
 		UserInfoPath:      fmt.Sprintf("%s/userinfo", opts.ProxyPrefix),
 
-		ProxyPrefix:           opts.ProxyPrefix,
-		provider:              opts.provider,
-		providerNameOverride:  opts.ProviderName,
-		sessionStore:          opts.sessionStore,
-		serveMux:              serveMux,
-		redirectURL:           redirectURL,
-		whitelistDomains:      opts.WhitelistDomains,
-		alwaysValidateSession: opts.AlwaysValidateSession,
-		skipAuthRegex:         opts.SkipAuthRegex,
-		skipAuthPreflight:     opts.SkipAuthPreflight,
-		skipJwtBearerTokens:   opts.SkipJwtBearerTokens,
-		jwtBearerVerifiers:    opts.jwtBearerVerifiers,
-		compiledRegex:         opts.compiledRegex,
-		SetXAuthRequest:       opts.SetXAuthRequest,
-		PassBasicAuth:         opts.PassBasicAuth,
-		SetBasicAuth:          opts.SetBasicAuth,
-		PassUserHeaders:       opts.PassUserHeaders,
-		BasicAuthPassword:     opts.BasicAuthPassword,
-		PassAccessToken:       opts.PassAccessToken,
-		SetAuthorization:      opts.SetAuthorization,
-		PassAuthorization:     opts.PassAuthorization,
-		PreferEmailToUser:     opts.PreferEmailToUser,
-		SkipProviderButton:    opts.SkipProviderButton,
-		templates:             loadTemplates(opts.CustomTemplatesDir),
-		Banner:                opts.Banner,
-		Footer:                opts.Footer,
+		ProxyPrefix:             opts.ProxyPrefix,
+		provider:                opts.provider,
+		providerNameOverride:    opts.ProviderName,
+		sessionStore:            opts.sessionStore,
+		serveMux:                serveMux,
+		redirectURL:             redirectURL,
+		whitelistDomains:        opts.WhitelistDomains,
+		strictSessionValidation: opts.StrictSessionValidation,
+		skipAuthRegex:           opts.SkipAuthRegex,
+		skipAuthPreflight:       opts.SkipAuthPreflight,
+		skipJwtBearerTokens:     opts.SkipJwtBearerTokens,
+		jwtBearerVerifiers:      opts.jwtBearerVerifiers,
+		compiledRegex:           opts.compiledRegex,
+		SetXAuthRequest:         opts.SetXAuthRequest,
+		PassBasicAuth:           opts.PassBasicAuth,
+		SetBasicAuth:            opts.SetBasicAuth,
+		PassUserHeaders:         opts.PassUserHeaders,
+		BasicAuthPassword:       opts.BasicAuthPassword,
+		PassAccessToken:         opts.PassAccessToken,
+		SetAuthorization:        opts.SetAuthorization,
+		PassAuthorization:       opts.PassAuthorization,
+		PreferEmailToUser:       opts.PreferEmailToUser,
+		SkipProviderButton:      opts.SkipProviderButton,
+		templates:               loadTemplates(opts.CustomTemplatesDir),
+		Banner:                  opts.Banner,
+		Footer:                  opts.Footer,
 	}
 }
 
@@ -927,7 +927,7 @@ func (p *OAuthProxy) getAuthenticatedSession(rw http.ResponseWriter, req *http.R
 		clearSession = true
 	}
 
-	if (saveSession || p.alwaysValidateSession) && !revalidated && session != nil && session.AccessToken != "" {
+	if (saveSession || p.strictSessionValidation) && !revalidated && session != nil && session.AccessToken != "" {
 		if !p.provider.ValidateSessionState(session) {
 			logger.Printf("Removing session: error validating %s", session)
 			saveSession = false

--- a/options.go
+++ b/options.go
@@ -68,6 +68,7 @@ type Options struct {
 	Session options.SessionOptions `cfg:",squash"`
 
 	Upstreams                     []string      `flag:"upstream" cfg:"upstreams" env:"OAUTH2_PROXY_UPSTREAMS"`
+	AlwaysValidateSession         bool          `flag:"always-validate-session" cfg:"always_validate_session" env:"OAUTH2_PROXY_ALWAYS_VALIDATE_SESSION"`
 	SkipAuthRegex                 []string      `flag:"skip-auth-regex" cfg:"skip_auth_regex" env:"OAUTH2_PROXY_SKIP_AUTH_REGEX"`
 	SkipJwtBearerTokens           bool          `flag:"skip-jwt-bearer-tokens" cfg:"skip_jwt_bearer_tokens" env:"OAUTH2_PROXY_SKIP_JWT_BEARER_TOKENS"`
 	ExtraJwtIssuers               []string      `flag:"extra-jwt-issuers" cfg:"extra_jwt_issuers" env:"OAUTH2_PROXY_EXTRA_JWT_ISSUERS"`
@@ -165,6 +166,7 @@ func NewOptions() *Options {
 		Session: options.SessionOptions{
 			Type: "cookie",
 		},
+		AlwaysValidateSession:            false,
 		SetXAuthRequest:                  false,
 		SkipAuthPreflight:                false,
 		PassBasicAuth:                    true,

--- a/options.go
+++ b/options.go
@@ -68,7 +68,7 @@ type Options struct {
 	Session options.SessionOptions `cfg:",squash"`
 
 	Upstreams                     []string      `flag:"upstream" cfg:"upstreams" env:"OAUTH2_PROXY_UPSTREAMS"`
-	AlwaysValidateSession         bool          `flag:"always-validate-session" cfg:"always_validate_session" env:"OAUTH2_PROXY_ALWAYS_VALIDATE_SESSION"`
+	StrictSessionValidation       bool          `flag:"strict-session-validation" cfg:"strict_session_validation" env:"OAUTH2_PROXY_STRICT_SESSION_VALIDATION"`
 	SkipAuthRegex                 []string      `flag:"skip-auth-regex" cfg:"skip_auth_regex" env:"OAUTH2_PROXY_SKIP_AUTH_REGEX"`
 	SkipJwtBearerTokens           bool          `flag:"skip-jwt-bearer-tokens" cfg:"skip_jwt_bearer_tokens" env:"OAUTH2_PROXY_SKIP_JWT_BEARER_TOKENS"`
 	ExtraJwtIssuers               []string      `flag:"extra-jwt-issuers" cfg:"extra_jwt_issuers" env:"OAUTH2_PROXY_EXTRA_JWT_ISSUERS"`
@@ -166,7 +166,7 @@ func NewOptions() *Options {
 		Session: options.SessionOptions{
 			Type: "cookie",
 		},
-		AlwaysValidateSession:            false,
+		StrictSessionValidation:          false,
 		SetXAuthRequest:                  false,
 		SkipAuthPreflight:                false,
 		PassBasicAuth:                    true,
@@ -381,7 +381,7 @@ func (o *Options) Validate() error {
 	msgs = parseProviderInfo(o, msgs)
 
 	var cipher *encryption.Cipher
-	if o.PassAccessToken || o.SetAuthorization || o.PassAuthorization || (o.Cookie.Refresh != time.Duration(0)) {
+	if o.StrictSessionValidation || o.PassAccessToken || o.SetAuthorization || o.PassAuthorization || (o.Cookie.Refresh != time.Duration(0)) {
 		validCookieSecretSize := false
 		for _, i := range []int{16, 24, 32} {
 			if len(secretBytes(o.Cookie.Secret)) == i {


### PR DESCRIPTION
Allows a `--strict-session-validation` flag to be passed which causes the provider `validateSessionState` to be called on all requests.

For OIDC provider, added to the validateSessionState to confirm the claims in the IDToken match the session User/Email/PreferredUsername after the IDToken is verified.

For OIDC, this isn't too expensive because the underlying go OIDC library caches the `.well-known` resources like jwks.json from the provider based on the cache settings in the response appropriately.
